### PR TITLE
Fixed initiation bug with missing private config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 #Ignore my token for the testing bot
 /priv/*
 /dbs/*
+.env

--- a/node_modules/dotenv/CHANGELOG.md
+++ b/node_modules/dotenv/CHANGELOG.md
@@ -1,0 +1,155 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## [8.2.0](https://github.com/motdotla/dotenv/compare/v8.1.0...v8.2.0) (2019-10-16)
+
+## [8.1.0](https://github.com/motdotla/dotenv/compare/v7.0.0...v8.1.0) (2019-08-18)
+
+
+### ⚠ BREAKING CHANGES
+
+* dropping Node v6 support because end-of-life
+
+* Drop support for Node v6 (#392) ([2e9636a](https://github.com/motdotla/dotenv/commit/2e9636a)), closes [#392](https://github.com/motdotla/dotenv/issues/392)
+
+# [8.0.0](https://github.com/motdotla/dotenv/compare/v7.0.0...v8.0.0) (2019-05-02)
+
+- Drop support for Node v6 (#392) ([2e9636a](https://github.com/motdotla/dotenv/commit/2e9636a)), closes [#392](https://github.com/motdotla/dotenv/issues/392)
+
+### BREAKING CHANGES
+
+- dropping Node v6 support because end-of-life
+
+## [7.0.0] - 2019-03-12
+
+### Fixed
+
+- Fix removing unbalanced quotes ([#376](https://github.com/motdotla/dotenv/pull/376))
+
+### Removed
+
+- Removed `load` alias for `config` for consistency throughout code and documentation.
+
+## [6.2.0] - 2018-12-03
+
+### Added
+
+- Support preload configuration via environment variables ([#351](https://github.com/motdotla/dotenv/issues/351))
+
+## [6.1.0] - 2018-10-08
+
+### Added
+
+- `debug` option for `config` and `parse` methods will turn on logging
+
+## [6.0.0] - 2018-06-02
+
+### Changed
+
+- _Breaking:_ drop support for Node v4 ([#304](https://github.com/motdotla/dotenv/pull/304))
+
+## [5.0.0] - 2018-01-29
+
+### Added
+
+- Testing against Node v8 and v9
+- Documentation on trim behavior of values
+- Documentation on how to use with `import`
+
+### Changed
+
+- _Breaking_: default `path` is now `path.resolve(process.cwd(), '.env')`
+- _Breaking_: does not write over keys already in `process.env` if the key has a falsy value
+- using `const` and `let` instead of `var`
+
+### Removed
+
+- Testing against Node v7
+
+## [4.0.0] - 2016-12-23
+
+### Changed
+
+- Return Object with parsed content or error instead of false ([#165](https://github.com/motdotla/dotenv/pull/165)).
+
+### Removed
+
+- `verbose` option removed in favor of returning result.
+
+## [3.0.0] - 2016-12-20
+
+### Added
+
+- `verbose` option will log any error messages. Off by default.
+- parses email addresses correctly
+- allow importing config method directly in ES6
+
+### Changed
+
+- Suppress error messages by default ([#154](https://github.com/motdotla/dotenv/pull/154))
+- Ignoring more files for NPM to make package download smaller
+
+### Fixed
+
+- False positive test due to case-sensitive variable ([#124](https://github.com/motdotla/dotenv/pull/124))
+
+### Removed
+
+- `silent` option removed in favor of `verbose`
+
+## [2.0.0] - 2016-01-20
+
+### Added
+
+- CHANGELOG to ["make it easier for users and contributors to see precisely what notable changes have been made between each release"](http://keepachangelog.com/). Linked to from README
+- LICENSE to be more explicit about what was defined in `package.json`. Linked to from README
+- Testing nodejs v4 on travis-ci
+- added examples of how to use dotenv in different ways
+- return parsed object on success rather than boolean true
+
+### Changed
+
+- README has shorter description not referencing ruby gem since we don't have or want feature parity
+
+### Removed
+
+- Variable expansion and escaping so environment variables are encouraged to be fully orthogonal
+
+## [1.2.0] - 2015-06-20
+
+### Added
+
+- Preload hook to require dotenv without including it in your code
+
+### Changed
+
+- clarified license to be "BSD-2-Clause" in `package.json`
+
+### Fixed
+
+- retain spaces in string vars
+
+## [1.1.0] - 2015-03-31
+
+### Added
+
+- Silent option to silence `console.log` when `.env` missing
+
+## [1.0.0] - 2015-03-13
+
+### Removed
+
+- support for multiple `.env` files. should always use one `.env` file for the current environment
+
+[7.0.0]: https://github.com/motdotla/dotenv/compare/v6.2.0...v7.0.0
+[6.2.0]: https://github.com/motdotla/dotenv/compare/v6.1.0...v6.2.0
+[6.1.0]: https://github.com/motdotla/dotenv/compare/v6.0.0...v6.1.0
+[6.0.0]: https://github.com/motdotla/dotenv/compare/v5.0.0...v6.0.0
+[5.0.0]: https://github.com/motdotla/dotenv/compare/v4.0.0...v5.0.0
+[4.0.0]: https://github.com/motdotla/dotenv/compare/v3.0.0...v4.0.0
+[3.0.0]: https://github.com/motdotla/dotenv/compare/v2.0.0...v3.0.0
+[2.0.0]: https://github.com/motdotla/dotenv/compare/v1.2.0...v2.0.0
+[1.2.0]: https://github.com/motdotla/dotenv/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/motdotla/dotenv/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/motdotla/dotenv/compare/v0.4.0...v1.0.0

--- a/node_modules/dotenv/LICENSE
+++ b/node_modules/dotenv/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2015, Scott Motte
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/node_modules/dotenv/README.md
+++ b/node_modules/dotenv/README.md
@@ -1,0 +1,271 @@
+# dotenv
+
+<img src="https://raw.githubusercontent.com/motdotla/dotenv/master/dotenv.png" alt="dotenv" align="right" />
+
+Dotenv is a zero-dependency module that loads environment variables from a `.env` file into [`process.env`](https://nodejs.org/docs/latest/api/process.html#process_process_env). Storing configuration in the environment separate from code is based on [The Twelve-Factor App](http://12factor.net/config) methodology.
+
+[![BuildStatus](https://img.shields.io/travis/motdotla/dotenv/master.svg?style=flat-square)](https://travis-ci.org/motdotla/dotenv)
+[![Build status](https://ci.appveyor.com/api/projects/status/github/motdotla/dotenv?svg=true)](https://ci.appveyor.com/project/motdotla/dotenv/branch/master)
+[![NPM version](https://img.shields.io/npm/v/dotenv.svg?style=flat-square)](https://www.npmjs.com/package/dotenv)
+[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/feross/standard)
+[![Coverage Status](https://img.shields.io/coveralls/motdotla/dotenv/master.svg?style=flat-square)](https://coveralls.io/github/motdotla/dotenv?branch=coverall-intergration)
+[![LICENSE](https://img.shields.io/github/license/motdotla/dotenv.svg)](LICENSE)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
+
+## Install
+
+```bash
+# with npm
+npm install dotenv
+
+# or with Yarn
+yarn add dotenv
+```
+
+## Usage
+
+As early as possible in your application, require and configure dotenv.
+
+```javascript
+require('dotenv').config()
+```
+
+Create a `.env` file in the root directory of your project. Add
+environment-specific variables on new lines in the form of `NAME=VALUE`.
+For example:
+
+```dosini
+DB_HOST=localhost
+DB_USER=root
+DB_PASS=s1mpl3
+```
+
+`process.env` now has the keys and values you defined in your `.env` file.
+
+```javascript
+const db = require('db')
+db.connect({
+  host: process.env.DB_HOST,
+  username: process.env.DB_USER,
+  password: process.env.DB_PASS
+})
+```
+
+### Preload
+
+You can use the `--require` (`-r`) [command line option](https://nodejs.org/api/cli.html#cli_r_require_module) to preload dotenv. By doing this, you do not need to require and load dotenv in your application code. This is the preferred approach when using `import` instead of `require`.
+
+```bash
+$ node -r dotenv/config your_script.js
+```
+
+The configuration options below are supported as command line arguments in the format `dotenv_config_<option>=value`
+
+```bash
+$ node -r dotenv/config your_script.js dotenv_config_path=/custom/path/to/your/env/vars
+```
+
+Additionally, you can use environment variables to set configuration options. Command line arguments will precede these.
+
+```bash
+$ DOTENV_CONFIG_<OPTION>=value node -r dotenv/config your_script.js
+```
+
+```bash
+$ DOTENV_CONFIG_ENCODING=latin1 node -r dotenv/config your_script.js dotenv_config_path=/custom/path/to/.env
+```
+
+## Config
+
+`config` will read your `.env` file, parse the contents, assign it to
+[`process.env`](https://nodejs.org/docs/latest/api/process.html#process_process_env),
+and return an Object with a `parsed` key containing the loaded content or an `error` key if it failed.
+
+```js
+const result = dotenv.config()
+
+if (result.error) {
+  throw result.error
+}
+
+console.log(result.parsed)
+```
+
+You can additionally, pass options to `config`.
+
+### Options
+
+#### Path
+
+Default: `path.resolve(process.cwd(), '.env')`
+
+You may specify a custom path if your file containing environment variables is located elsewhere.
+
+```js
+require('dotenv').config({ path: '/full/custom/path/to/your/env/vars' })
+```
+
+#### Encoding
+
+Default: `utf8`
+
+You may specify the encoding of your file containing environment variables.
+
+```js
+require('dotenv').config({ encoding: 'latin1' })
+```
+
+#### Debug
+
+Default: `false`
+
+You may turn on logging to help debug why certain keys or values are not being set as you expect.
+
+```js
+require('dotenv').config({ debug: process.env.DEBUG })
+```
+
+## Parse
+
+The engine which parses the contents of your file containing environment
+variables is available to use. It accepts a String or Buffer and will return
+an Object with the parsed keys and values.
+
+```js
+const dotenv = require('dotenv')
+const buf = Buffer.from('BASIC=basic')
+const config = dotenv.parse(buf) // will return an object
+console.log(typeof config, config) // object { BASIC : 'basic' }
+```
+
+### Options
+
+#### Debug
+
+Default: `false`
+
+You may turn on logging to help debug why certain keys or values are not being set as you expect.
+
+```js
+const dotenv = require('dotenv')
+const buf = Buffer.from('hello world')
+const opt = { debug: true }
+const config = dotenv.parse(buf, opt)
+// expect a debug message because the buffer is not in KEY=VAL form
+```
+
+### Rules
+
+The parsing engine currently supports the following rules:
+
+- `BASIC=basic` becomes `{BASIC: 'basic'}`
+- empty lines are skipped
+- lines beginning with `#` are treated as comments
+- empty values become empty strings (`EMPTY=` becomes `{EMPTY: ''}`)
+- inner quotes are maintained (think JSON) (`JSON={"foo": "bar"}` becomes `{JSON:"{\"foo\": \"bar\"}"`)
+- whitespace is removed from both ends of unquoted values (see more on [`trim`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim)) (`FOO=  some value  ` becomes `{FOO: 'some value'}`)
+- single and double quoted values are escaped (`SINGLE_QUOTE='quoted'` becomes `{SINGLE_QUOTE: "quoted"}`)
+- single and double quoted values maintain whitespace from both ends (`FOO="  some value  "` becomes `{FOO: '  some value  '}`)
+- double quoted values expand new lines (`MULTILINE="new\nline"` becomes
+
+```
+{MULTILINE: 'new
+line'}
+```
+
+## FAQ
+
+### Should I commit my `.env` file?
+
+No. We **strongly** recommend against committing your `.env` file to version
+control. It should only include environment-specific values such as database
+passwords or API keys. Your production database should have a different
+password than your development database.
+
+### Should I have multiple `.env` files?
+
+No. We **strongly** recommend against having a "main" `.env` file and an "environment" `.env` file like `.env.test`. Your config should vary between deploys, and you should not be sharing values between environments.
+
+> In a twelve-factor app, env vars are granular controls, each fully orthogonal to other env vars. They are never grouped together as “environments”, but instead are independently managed for each deploy. This is a model that scales up smoothly as the app naturally expands into more deploys over its lifetime.
+>
+> – [The Twelve-Factor App](http://12factor.net/config)
+
+### What happens to environment variables that were already set?
+
+We will never modify any environment variables that have already been set. In particular, if there is a variable in your `.env` file which collides with one that already exists in your environment, then that variable will be skipped. This behavior allows you to override all `.env` configurations with a machine-specific environment, although it is not recommended.
+
+If you want to override `process.env` you can do something like this:
+
+```javascript
+const fs = require('fs')
+const dotenv = require('dotenv')
+const envConfig = dotenv.parse(fs.readFileSync('.env.override'))
+for (const k in envConfig) {
+  process.env[k] = envConfig[k]
+}
+```
+
+### Can I customize/write plugins for dotenv?
+
+For `dotenv@2.x.x`: Yes. `dotenv.config()` now returns an object representing
+the parsed `.env` file. This gives you everything you need to continue
+setting values on `process.env`. For example:
+
+```js
+const dotenv = require('dotenv')
+const variableExpansion = require('dotenv-expand')
+const myEnv = dotenv.config()
+variableExpansion(myEnv)
+```
+
+### What about variable expansion?
+
+Try [dotenv-expand](https://github.com/motdotla/dotenv-expand)
+
+### How do I use dotenv with `import`?
+
+ES2015 and beyond offers modules that allow you to `export` any top-level `function`, `class`, `var`, `let`, or `const`.
+
+> When you run a module containing an `import` declaration, the modules it imports are loaded first, then each module body is executed in a depth-first traversal of the dependency graph, avoiding cycles by skipping anything already executed.
+>
+> – [ES6 In Depth: Modules](https://hacks.mozilla.org/2015/08/es6-in-depth-modules/)
+
+You must run `dotenv.config()` before referencing any environment variables. Here's an example of problematic code:
+
+`errorReporter.js`:
+
+```js
+import { Client } from 'best-error-reporting-service'
+
+export const client = new Client(process.env.BEST_API_KEY)
+```
+
+`index.js`:
+
+```js
+import dotenv from 'dotenv'
+import errorReporter from './errorReporter'
+
+dotenv.config()
+errorReporter.client.report(new Error('faq example'))
+```
+
+`client` will not be configured correctly because it was constructed before `dotenv.config()` was executed. There are (at least) 3 ways to make this work.
+
+1. Preload dotenv: `node --require dotenv/config index.js` (_Note: you do not need to `import` dotenv with this approach_)
+2. Import `dotenv/config` instead of `dotenv` (_Note: you do not need to call `dotenv.config()` and must pass options via the command line or environment variables with this approach_)
+3. Create a separate file that will execute `config` first as outlined in [this comment on #133](https://github.com/motdotla/dotenv/issues/133#issuecomment-255298822)
+
+## Contributing Guide
+
+See [CONTRIBUTING.md](CONTRIBUTING.md)
+
+## Change Log
+
+See [CHANGELOG.md](CHANGELOG.md)
+
+## Who's using dotenv?
+
+[These npm modules depend on it.](https://www.npmjs.com/browse/depended/dotenv)
+
+Projects that expand it often use the [keyword "dotenv" on npm](https://www.npmjs.com/search?q=keywords:dotenv).

--- a/node_modules/dotenv/config.js
+++ b/node_modules/dotenv/config.js
@@ -1,0 +1,11 @@
+/* @flow */
+
+(function () {
+  require('./lib/main').config(
+    Object.assign(
+      {},
+      require('./lib/env-options'),
+      require('./lib/cli-options')(process.argv)
+    )
+  )
+})()

--- a/node_modules/dotenv/lib/cli-options.js
+++ b/node_modules/dotenv/lib/cli-options.js
@@ -1,0 +1,13 @@
+/* @flow */
+
+const re = /^dotenv_config_(encoding|path|debug)=(.+)$/
+
+module.exports = function optionMatcher (args /*: Array<string> */) {
+  return args.reduce(function (acc, cur) {
+    const matches = cur.match(re)
+    if (matches) {
+      acc[matches[1]] = matches[2]
+    }
+    return acc
+  }, {})
+}

--- a/node_modules/dotenv/lib/env-options.js
+++ b/node_modules/dotenv/lib/env-options.js
@@ -1,0 +1,18 @@
+/* @flow */
+
+// ../config.js accepts options via environment variables
+const options = {}
+
+if (process.env.DOTENV_CONFIG_ENCODING != null) {
+  options.encoding = process.env.DOTENV_CONFIG_ENCODING
+}
+
+if (process.env.DOTENV_CONFIG_PATH != null) {
+  options.path = process.env.DOTENV_CONFIG_PATH
+}
+
+if (process.env.DOTENV_CONFIG_DEBUG != null) {
+  options.debug = process.env.DOTENV_CONFIG_DEBUG
+}
+
+module.exports = options

--- a/node_modules/dotenv/lib/main.js
+++ b/node_modules/dotenv/lib/main.js
@@ -1,0 +1,113 @@
+/* @flow */
+/*::
+
+type DotenvParseOptions = {
+  debug?: boolean
+}
+
+// keys and values from src
+type DotenvParseOutput = { [string]: string }
+
+type DotenvConfigOptions = {
+  path?: string, // path to .env file
+  encoding?: string, // encoding of .env file
+  debug?: string // turn on logging for debugging purposes
+}
+
+type DotenvConfigOutput = {
+  parsed?: DotenvParseOutput,
+  error?: Error
+}
+
+*/
+
+const fs = require('fs')
+const path = require('path')
+
+function log (message /*: string */) {
+  console.log(`[dotenv][DEBUG] ${message}`)
+}
+
+const NEWLINE = '\n'
+const RE_INI_KEY_VAL = /^\s*([\w.-]+)\s*=\s*(.*)?\s*$/
+const RE_NEWLINES = /\\n/g
+const NEWLINES_MATCH = /\n|\r|\r\n/
+
+// Parses src into an Object
+function parse (src /*: string | Buffer */, options /*: ?DotenvParseOptions */) /*: DotenvParseOutput */ {
+  const debug = Boolean(options && options.debug)
+  const obj = {}
+
+  // convert Buffers before splitting into lines and processing
+  src.toString().split(NEWLINES_MATCH).forEach(function (line, idx) {
+    // matching "KEY' and 'VAL' in 'KEY=VAL'
+    const keyValueArr = line.match(RE_INI_KEY_VAL)
+    // matched?
+    if (keyValueArr != null) {
+      const key = keyValueArr[1]
+      // default undefined or missing values to empty string
+      let val = (keyValueArr[2] || '')
+      const end = val.length - 1
+      const isDoubleQuoted = val[0] === '"' && val[end] === '"'
+      const isSingleQuoted = val[0] === "'" && val[end] === "'"
+
+      // if single or double quoted, remove quotes
+      if (isSingleQuoted || isDoubleQuoted) {
+        val = val.substring(1, end)
+
+        // if double quoted, expand newlines
+        if (isDoubleQuoted) {
+          val = val.replace(RE_NEWLINES, NEWLINE)
+        }
+      } else {
+        // remove surrounding whitespace
+        val = val.trim()
+      }
+
+      obj[key] = val
+    } else if (debug) {
+      log(`did not match key and value when parsing line ${idx + 1}: ${line}`)
+    }
+  })
+
+  return obj
+}
+
+// Populates process.env from .env file
+function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ {
+  let dotenvPath = path.resolve(process.cwd(), '.env')
+  let encoding /*: string */ = 'utf8'
+  let debug = false
+
+  if (options) {
+    if (options.path != null) {
+      dotenvPath = options.path
+    }
+    if (options.encoding != null) {
+      encoding = options.encoding
+    }
+    if (options.debug != null) {
+      debug = true
+    }
+  }
+
+  try {
+    // specifying an encoding returns a string instead of a buffer
+    const parsed = parse(fs.readFileSync(dotenvPath, { encoding }), { debug })
+
+    Object.keys(parsed).forEach(function (key) {
+      if (!Object.prototype.hasOwnProperty.call(process.env, key)) {
+        process.env[key] = parsed[key]
+      } else if (debug) {
+        log(`"${key}" is already defined in \`process.env\` and will not be overwritten`)
+      }
+    })
+
+    return { parsed }
+  } catch (e) {
+    return { error: e }
+  }
+}
+
+module.exports.config = config
+module.exports.parse = parse

--- a/node_modules/dotenv/package.json
+++ b/node_modules/dotenv/package.json
@@ -1,0 +1,80 @@
+{
+  "_from": "dotenv",
+  "_id": "dotenv@8.2.0",
+  "_inBundle": false,
+  "_integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+  "_location": "/dotenv",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "tag",
+    "registry": true,
+    "raw": "dotenv",
+    "name": "dotenv",
+    "escapedName": "dotenv",
+    "rawSpec": "",
+    "saveSpec": null,
+    "fetchSpec": "latest"
+  },
+  "_requiredBy": [
+    "#USER",
+    "/"
+  ],
+  "_resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+  "_shasum": "97e619259ada750eea3e4ea3e26bceea5424b16a",
+  "_spec": "dotenv",
+  "_where": "D:\\Projects\\BlacklistedWordsBot",
+  "bugs": {
+    "url": "https://github.com/motdotla/dotenv/issues"
+  },
+  "bundleDependencies": false,
+  "dependencies": {},
+  "deprecated": false,
+  "description": "Loads environment variables from .env file",
+  "devDependencies": {
+    "decache": "^4.5.1",
+    "dtslint": "^0.9.8",
+    "flow-bin": "^0.109.0",
+    "sinon": "^7.5.0",
+    "standard": "^13.1.0",
+    "standard-markdown": "^5.1.0",
+    "standard-version": "^7.0.0",
+    "tap": "^14.7.0"
+  },
+  "engines": {
+    "node": ">=8"
+  },
+  "homepage": "https://github.com/motdotla/dotenv#readme",
+  "keywords": [
+    "dotenv",
+    "env",
+    ".env",
+    "environment",
+    "variables",
+    "config",
+    "settings"
+  ],
+  "license": "BSD-2-Clause",
+  "main": "lib/main.js",
+  "name": "dotenv",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/motdotla/dotenv.git"
+  },
+  "scripts": {
+    "dtslint": "dtslint types",
+    "flow": "flow",
+    "lint": "standard",
+    "postlint": "standard-markdown",
+    "prerelease": "npm test",
+    "pretest": "npm run lint && npm run dtslint",
+    "release": "standard-version",
+    "test": "tap tests/*.js --100"
+  },
+  "standard": {
+    "ignore": [
+      "flow-typed/"
+    ]
+  },
+  "types": "types",
+  "version": "8.2.0"
+}

--- a/node_modules/dotenv/types/index.d.ts
+++ b/node_modules/dotenv/types/index.d.ts
@@ -1,0 +1,59 @@
+// TypeScript Version: 3.0
+/// <reference types="node" />
+
+export interface DotenvParseOptions {
+  /**
+   * You may turn on logging to help debug why certain keys or values are not being set as you expect.
+   */
+  debug?: boolean;
+}
+
+export interface DotenvParseOutput {
+  [name: string]: string;
+}
+
+/**
+ * Parses a string or buffer in the .env file format into an object.
+ *
+ * @param src - contents to be parsed
+ * @param options - additional options
+ * @returns an object with keys and values based on `src`
+ */
+export function parse(
+  src: string | Buffer,
+  options?: DotenvParseOptions
+): DotenvParseOutput;
+
+export interface DotenvConfigOptions {
+  /**
+   * You may specify a custom path if your file containing environment variables is located elsewhere.
+   */
+  path?: string;
+
+  /**
+   * You may specify the encoding of your file containing environment variables.
+   */
+  encoding?: string;
+
+  /**
+   * You may turn on logging to help debug why certain keys or values are not being set as you expect.
+   */
+  debug?: boolean;
+}
+
+export interface DotenvConfigOutput {
+  error?: Error;
+  parsed?: DotenvParseOutput;
+}
+
+/**
+ * Loads `.env` file contents into {@link https://nodejs.org/api/process.html#process_process_env | `process.env`}.
+ * Example: 'KEY=value' becomes { parsed: { KEY: 'value' } }
+ *
+ * @param options - controls behavior
+ * @returns an object with a `parsed` key if successful or `error` key if an error occurred
+ *
+ */
+export function config(options?: DotenvConfigOptions): DotenvConfigOutput;
+/** @deprecated since v7.0.0 Use config instead. */
+export const load: typeof config;

--- a/node_modules/dotenv/types/test.ts
+++ b/node_modules/dotenv/types/test.ts
@@ -1,0 +1,19 @@
+import { config, parse } from "dotenv";
+
+const env = config();
+const dbUrl: string | null =
+  env.error || !env.parsed ? null : env.parsed["BASIC"];
+
+config({
+  path: ".env-example",
+  encoding: "utf8",
+  debug: true
+});
+
+const parsed = parse("NODE_ENV=production\nDB_HOST=a.b.c");
+const dbHost: string = parsed["DB_HOST"];
+
+const parsedFromBuffer = parse(new Buffer("JUSTICE=league\n"), {
+  debug: true
+});
+const justice: string = parsedFromBuffer["JUSTICE"];

--- a/node_modules/dotenv/types/tsconfig.json
+++ b/node_modules/dotenv/types/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": ["es6"],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "dotenv": ["."]
+    }
+  }
+}

--- a/node_modules/dotenv/types/tslint.json
+++ b/node_modules/dotenv/types/tslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "dtslint/dtslint.json",
+  "rules": {
+    "strict-export-declare-modifiers": false
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -226,6 +226,11 @@
         "ws": "^7.3.1"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "discord.js": "^12.3.1",
+    "dotenv": "^8.2.0",
     "sql-template-strings": "^2.2.2",
     "sqlite": "^4.0.15",
     "sqlite3": "^5.0.0",


### PR DESCRIPTION
I had a .gitignore file removed a private config file, of course when you download this repo, that does not get downloaded but the code still checks for it.
Instead we have the ability to set the API key in config.json or a .env file.
resolves #6 